### PR TITLE
Use proper PropTypes package

### DIFF
--- a/boilerplate/App/Containers/LoginScreen.js
+++ b/boilerplate/App/Containers/LoginScreen.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import React from "react";
+import PropTypes from "prop-types";
 import { View, ScrollView, Text, TextInput, TouchableOpacity, Image, Keyboard, LayoutAnimation } from "react-native";
 import { connect } from "react-redux";
 import Styles from "./Styles/LoginScreenStyles";


### PR DESCRIPTION
Getting [this error](https://stackoverflow.com/questions/42542540/react2-default-proptypes-function-is-undefined) because:

>React.PropTypes has moved into a different package since React v15.5. Please use the prop-types library instead.