### PR TITLE
Fix regex pattern to support 'react-navigation'

### DIFF
--- a/lib/patterns.js
+++ b/lib/patterns.js
@@ -5,6 +5,6 @@ const constants = {
 
 module.exports = {
 	constants,
-	[constants.PATTERN_IMPORTS]: `import[\\s\\D]*from\\s+"react-navigation";?`,
+	[constants.PATTERN_IMPORTS]: `import[\\s\\D]*from\\s+('|")react-navigation('|");?`,
 	[constants.PATTERN_ROUTES]: "const NavigationDrawer",
 };


### PR DESCRIPTION
Fixex regex pattern to support both:

import ... from "react-navigation";
and
import ... from 'react-navigation';